### PR TITLE
Fix compilation issue

### DIFF
--- a/src/TextUI.cc
+++ b/src/TextUI.cc
@@ -312,11 +312,11 @@ void TextUI::drawui()
 
 		move(row,58);
 		if( ic->getIdleSeconds() < 60 )
-			printw("%ds",ic->getIdleSeconds());
+			printw("%ds",(int)ic->getIdleSeconds());
 		else if( ic->getIdleSeconds() < 3600 ) 
-			printw("%dm",ic->getIdleSeconds()/60);
+			printw("%dm",(int)ic->getIdleSeconds()/60);
 		else
-			printw("%dh",ic->getIdleSeconds()/3600);
+			printw("%dh",(int)ic->getIdleSeconds()/3600);
 
 		move(row,63);
 		if( ic->activityToggle() )


### PR DESCRIPTION
time_t byte count differs in different systems. It was causing a compilation issue as it was assumed to be 4 bytes long.